### PR TITLE
Add Pilz planner configuration

### DIFF
--- a/src/003_moveit_config/config/pilz_planning.yaml
+++ b/src/003_moveit_config/config/pilz_planning.yaml
@@ -1,0 +1,11 @@
+planner_configs:
+  PTP: {}
+  LIN: {}
+  CIRC: {}
+
+arm:
+  default_planner_config: PTP
+  planner_configs:
+    - PTP
+    - LIN
+    - CIRC

--- a/src/003_moveit_config/launch/pilz_industrial_motion_planner_planning_pipeline.launch.xml
+++ b/src/003_moveit_config/launch/pilz_industrial_motion_planner_planning_pipeline.launch.xml
@@ -9,6 +9,9 @@
   <!-- Define default planner (for all groups) -->
   <param name="default_planner_config" value="PTP" />
 
+  <!-- Load planner configuration including PTP, LIN and CIRC -->
+  <rosparam command="load" file="$(find 003_moveit_config)/config/pilz_planning.yaml" />
+
   <!-- MoveGroup capabilities to load for this pipeline, append sequence capability -->
   <param name="capabilities" value="pilz_industrial_motion_planner/MoveGroupSequenceAction
                                     pilz_industrial_motion_planner/MoveGroupSequenceService" />


### PR DESCRIPTION
## Summary
- configure Pilz planning pipeline to load `pilz_planning.yaml`
- add basic planner config for PTP, LIN and CIRC

## Testing
- `catkin_make run_tests` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686dd2a892d48329af4d62071d97c098